### PR TITLE
Add metadata support to addDocuments

### DIFF
--- a/Chroma/Sources/ChromaMetadata.swift
+++ b/Chroma/Sources/ChromaMetadata.swift
@@ -1,0 +1,117 @@
+// Copyright 2026 Chroma
+// Licensed under the Apache License, Version 2.0
+
+import Foundation
+
+public enum ChromaMetadataValue: Hashable, Sendable {
+    case bool(Bool)
+    case int(Int64)
+    case float(Double)
+    case string(String)
+}
+
+extension ChromaMetadataValue: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .bool(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .float(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+extension ChromaMetadataValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
+}
+
+extension ChromaMetadataValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int64) {
+        self = .int(value)
+    }
+}
+
+extension ChromaMetadataValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .float(value)
+    }
+}
+
+extension ChromaMetadataValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+public typealias ChromaMetadata = [String: ChromaMetadataValue]
+
+public enum ChromaMetadataError: Error, LocalizedError {
+    case countMismatch(expected: Int, actual: Int)
+    case encodingFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case let .countMismatch(expected, actual):
+            return "Metadata count (\(actual)) does not match ids count (\(expected))."
+        case .encodingFailed:
+            return "Failed to encode metadata as JSON."
+        }
+    }
+}
+
+private extension Dictionary where Key == String, Value == ChromaMetadataValue {
+    func chromaJSON() throws -> String {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw ChromaMetadataError.encodingFailed
+        }
+        return json
+    }
+}
+
+public func addDocuments(
+    collectionName: String,
+    ids: [String],
+    embeddings: [[Float]],
+    documents: [String]
+) throws -> UInt32 {
+    return try addDocuments(
+        collectionName: collectionName,
+        ids: ids,
+        embeddings: embeddings,
+        documents: documents,
+        metadatas: nil as [String?]?
+    )
+}
+
+public func addDocuments(
+    collectionName: String,
+    ids: [String],
+    embeddings: [[Float]],
+    documents: [String],
+    metadatas: [ChromaMetadata?]
+) throws -> UInt32 {
+    if metadatas.count != ids.count {
+        throw ChromaMetadataError.countMismatch(expected: ids.count, actual: metadatas.count)
+    }
+
+    let metadatasJSON = try metadatas.map { metadata in
+        try metadata?.chromaJSON()
+    }
+
+    return try addDocuments(
+        collectionName: collectionName,
+        ids: ids,
+        embeddings: embeddings,
+        documents: documents,
+        metadatas: metadatasJSON
+    )
+}

--- a/Chroma/Sources/ChromaMetadata.swift
+++ b/Chroma/Sources/ChromaMetadata.swift
@@ -102,9 +102,9 @@ public extension AdvancedGetResult {
             return Array(repeating: nil, count: ids.count)
         }
 
-        let decoded = metadatas.map { json in
-            guard let json else { return nil }
-            guard let data = json.data(using: .utf8) else { return nil }
+        let decoded: [ChromaMetadata?] = metadatas.map { json in
+            guard let json else { return nil as ChromaMetadata? }
+            guard let data = json.data(using: .utf8) else { return nil as ChromaMetadata? }
             return try? JSONDecoder().decode(ChromaMetadata.self, from: data)
         }
 

--- a/Chroma/Sources/ChromaSwift.swift
+++ b/Chroma/Sources/ChromaSwift.swift
@@ -572,10 +572,10 @@ public struct FfiConverterTypeAdvancedGetResult: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AdvancedGetResult {
         return
             try AdvancedGetResult(
-                ids: FfiConverterSequenceString.read(from: &buf),
-                embeddings: FfiConverterOptionSequenceSequenceFloat.read(from: &buf),
-                documents: FfiConverterOptionSequenceOptionString.read(from: &buf),
-                metadatas: FfiConverterOptionSequenceOptionString.read(from: &buf),
+                ids: FfiConverterSequenceString.read(from: &buf), 
+                embeddings: FfiConverterOptionSequenceSequenceFloat.read(from: &buf), 
+                documents: FfiConverterOptionSequenceOptionString.read(from: &buf), 
+                metadatas: FfiConverterOptionSequenceOptionString.read(from: &buf), 
                 uris: FfiConverterOptionSequenceOptionString.read(from: &buf)
         )
     }
@@ -654,8 +654,8 @@ public struct FfiConverterTypeCollectionInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CollectionInfo {
         return
             try CollectionInfo(
-                name: FfiConverterString.read(from: &buf),
-                collectionId: FfiConverterString.read(from: &buf),
+                name: FfiConverterString.read(from: &buf), 
+                collectionId: FfiConverterString.read(from: &buf), 
                 numDocuments: FfiConverterUInt32.read(from: &buf)
         )
     }
@@ -732,8 +732,8 @@ public struct FfiConverterTypeDatabaseInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DatabaseInfo {
         return
             try DatabaseInfo(
-                id: FfiConverterString.read(from: &buf),
-                name: FfiConverterString.read(from: &buf),
+                id: FfiConverterString.read(from: &buf), 
+                name: FfiConverterString.read(from: &buf), 
                 tenant: FfiConverterString.read(from: &buf)
         )
     }
@@ -804,7 +804,7 @@ public struct FfiConverterTypeGetResult: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GetResult {
         return
             try GetResult(
-                ids: FfiConverterSequenceString.read(from: &buf),
+                ids: FfiConverterSequenceString.read(from: &buf), 
                 documents: FfiConverterSequenceOptionString.read(from: &buf)
         )
     }
@@ -874,7 +874,7 @@ public struct FfiConverterTypeQueryResult: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> QueryResult {
         return
             try QueryResult(
-                ids: FfiConverterSequenceSequenceString.read(from: &buf),
+                ids: FfiConverterSequenceSequenceString.read(from: &buf), 
                 documents: FfiConverterSequenceSequenceOptionString.read(from: &buf)
         )
     }
@@ -1245,13 +1245,14 @@ fileprivate struct FfiConverterSequenceSequenceOptionString: FfiConverterRustBuf
         return seq
     }
 }
-public func addDocuments(collectionName: String, ids: [String], embeddings: [[Float]], documents: [String])throws  -> UInt32  {
+public func addDocuments(collectionName: String, ids: [String], embeddings: [[Float]], documents: [String], metadatas: [String?]?)throws  -> UInt32  {
     return try  FfiConverterUInt32.lift(try rustCallWithError(FfiConverterTypeChromaError_lift) {
     uniffi_chroma_swift_fn_func_add_documents(
         FfiConverterString.lower(collectionName),
         FfiConverterSequenceString.lower(ids),
         FfiConverterSequenceSequenceFloat.lower(embeddings),
-        FfiConverterSequenceString.lower(documents),$0
+        FfiConverterSequenceString.lower(documents),
+        FfiConverterOptionSequenceOptionString.lower(metadatas),$0
     )
 })
 }
@@ -1436,7 +1437,7 @@ private let initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if (uniffi_chroma_swift_checksum_func_add_documents() != 15974) {
+    if (uniffi_chroma_swift_checksum_func_add_documents() != 1910) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_chroma_swift_checksum_func_count_collections() != 52564) {

--- a/Chroma/Sources/ChromaSwift.swift
+++ b/Chroma/Sources/ChromaSwift.swift
@@ -572,12 +572,12 @@ public struct FfiConverterTypeAdvancedGetResult: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AdvancedGetResult {
         return
             try AdvancedGetResult(
-                ids: FfiConverterSequenceString.read(from: &buf), 
-                embeddings: FfiConverterOptionSequenceSequenceFloat.read(from: &buf), 
-                documents: FfiConverterOptionSequenceOptionString.read(from: &buf), 
-                metadatas: FfiConverterOptionSequenceOptionString.read(from: &buf), 
+                ids: FfiConverterSequenceString.read(from: &buf),
+                embeddings: FfiConverterOptionSequenceSequenceFloat.read(from: &buf),
+                documents: FfiConverterOptionSequenceOptionString.read(from: &buf),
+                metadatas: FfiConverterOptionSequenceOptionString.read(from: &buf),
                 uris: FfiConverterOptionSequenceOptionString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: AdvancedGetResult, into buf: inout [UInt8]) {
@@ -637,7 +637,7 @@ extension CollectionInfo: Equatable, Hashable {
         }
         return true
     }
-
+    
     public func hash(into hasher: inout Hasher) {
         hasher.combine(name)
         hasher.combine(collectionId)
@@ -654,8 +654,8 @@ public struct FfiConverterTypeCollectionInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CollectionInfo {
         return
             try CollectionInfo(
-                name: FfiConverterString.read(from: &buf), 
-                collectionId: FfiConverterString.read(from: &buf), 
+                name: FfiConverterString.read(from: &buf),
+                collectionId: FfiConverterString.read(from: &buf),
                 numDocuments: FfiConverterUInt32.read(from: &buf)
         )
     }
@@ -732,8 +732,8 @@ public struct FfiConverterTypeDatabaseInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DatabaseInfo {
         return
             try DatabaseInfo(
-                id: FfiConverterString.read(from: &buf), 
-                name: FfiConverterString.read(from: &buf), 
+                id: FfiConverterString.read(from: &buf),
+                name: FfiConverterString.read(from: &buf),
                 tenant: FfiConverterString.read(from: &buf)
         )
     }
@@ -804,7 +804,7 @@ public struct FfiConverterTypeGetResult: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GetResult {
         return
             try GetResult(
-                ids: FfiConverterSequenceString.read(from: &buf), 
+                ids: FfiConverterSequenceString.read(from: &buf),
                 documents: FfiConverterSequenceOptionString.read(from: &buf)
         )
     }
@@ -874,7 +874,7 @@ public struct FfiConverterTypeQueryResult: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> QueryResult {
         return
             try QueryResult(
-                ids: FfiConverterSequenceSequenceString.read(from: &buf), 
+                ids: FfiConverterSequenceSequenceString.read(from: &buf),
                 documents: FfiConverterSequenceSequenceOptionString.read(from: &buf)
         )
     }
@@ -902,11 +902,7 @@ public func FfiConverterTypeQueryResult_lower(_ value: QueryResult) -> RustBuffe
 
 
 public enum ChromaError: Swift.Error {
-
-    
-    
-    case Generic(message: String
-    )
+    case Generic(message: String)
 }
 
 
@@ -919,25 +915,15 @@ public struct FfiConverterTypeChromaError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChromaError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
-        
-
-        
         case 1: return .Generic(
             message: try FfiConverterString.read(from: &buf)
             )
-
          default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ChromaError, into buf: inout [UInt8]) {
         switch value {
-
-        
-
-        
-        
         case let .Generic(message):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(message, into: &buf)

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "chroma_swiftFFI",
-            url: "https://github.com/chroma-core/chroma-swift/releases/download/1.0.1/chroma_swift_framework.xcframework.zip",
-            checksum: "d438e2d46544947c59261fda17b2640c9b452e3afbdcdd3d1b2c28bee82c3d51"
+            url: "https://github.com/andrewgleave/chroma-swift/releases/download/1.0.2/chroma_swift_framework.xcframework.zip",
+            checksum: "938c3d396feddb9c985ca796a99b8c5612048939780d8cae648cacd74e874147"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "chroma_swiftFFI",
-            url: "https://github.com/andrewgleave/chroma-swift/releases/download/1.0.2/chroma_swift_framework.xcframework.zip",
-            checksum: "938c3d396feddb9c985ca796a99b8c5612048939780d8cae648cacd74e874147"
+            url: "https://github.com/chroma-core/chroma-swift/releases/download/1.0.1/chroma_swift_framework.xcframework.zip",
+            checksum: "d438e2d46544947c59261fda17b2640c9b452e3afbdcdd3d1b2c28bee82c3d51"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ let results = try await embedder.queryCollection(collectionName, queryText: "sim
 - `getDocuments(collectionName: String, ids: [String]?, whereClause: String?, limit: UInt32?, offset: UInt32?, whereDocument: String?, include: [String]?) -> AdvancedGetResult`
   
   Advanced document retrieval with filtering, pagination, and field selection.
+  Metadata values are returned as JSON strings; use `AdvancedGetResult.decodedMetadatas()` for typed decoding.
 
 - `updateDocuments(collectionName: String, ids: [String], embeddings: [[Float]]?, documents: [String]?)`
   

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ let results = try await embedder.queryCollection(collectionName, queryText: "sim
 - `addDocuments(collectionName: String, ids: [String], embeddings: [[Float]], documents: [String], metadatas: [ChromaMetadata?]? = nil) -> UInt32`
   
   Adds documents with embeddings and optional metadata to a collection.
+  Note: this currently returns `1` on success regardless of the number of documents; use `countDocuments` if you need the actual count.
 
 - `getAllDocuments(collectionName: String) -> GetResult`
   

--- a/README.md
+++ b/README.md
@@ -63,7 +63,17 @@ let collectionId = try Chroma.createCollection(name: collectionName)
 let ids = ["doc1", "doc2"]
 let embeddings: [[Float]] = [[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]]
 let documents = ["Document 1 text", "Document 2 text"]
-try Chroma.addDocuments(collectionName: collectionName, ids: ids, embeddings: embeddings, documents: documents)
+let metadatas: [ChromaMetadata?] = [
+    ["source": "manual", "rank": 1],
+    ["source": "manual", "rank": 2, "active": true]
+]
+try Chroma.addDocuments(
+    collectionName: collectionName,
+    ids: ids,
+    embeddings: embeddings,
+    documents: documents,
+    metadatas: metadatas
+)
 let results = try Chroma.queryCollection(collectionName: collectionName, queryEmbeddings: [[0.1, 0.2, 0.3]], nResults: 1, whereFilter: nil, ids: nil, include: nil)
 
 ```
@@ -86,11 +96,21 @@ try Chroma.initializeWithPath(path: chromaDirectory, allowReset: false)
 let collectionName = "persistent_collection"
 let collectionId = try Chroma.createCollection(name: collectionName)
 
-// Add documents as usual
+// Add documents as usual (with optional metadata)
 let ids = ["doc1", "doc2"]
 let embeddings: [[Float]] = [[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]]
 let documents = ["Document 1 text", "Document 2 text"]
-try Chroma.addDocuments(collectionName: collectionName, ids: ids, embeddings: embeddings, documents: documents)
+let metadatas: [ChromaMetadata?] = [
+    ["source": "manual", "rank": 1],
+    ["source": "manual", "rank": 2, "active": true]
+]
+try Chroma.addDocuments(
+    collectionName: collectionName,
+    ids: ids,
+    embeddings: embeddings,
+    documents: documents,
+    metadatas: metadatas
+)
 
 // Data will be preserved between app sessions
 ```
@@ -173,9 +193,9 @@ let results = try await embedder.queryCollection(collectionName, queryText: "sim
   Returns the total number of collections.
 
 ### Document/Record Management
-- `addDocuments(collectionName: String, ids: [String], embeddings: [[Float]], documents: [String]) -> UInt32`
+- `addDocuments(collectionName: String, ids: [String], embeddings: [[Float]], documents: [String], metadatas: [ChromaMetadata?]? = nil) -> UInt32`
   
-  Adds documents with embeddings to a collection.
+  Adds documents with embeddings and optional metadata to a collection.
 
 - `getAllDocuments(collectionName: String) -> GetResult`
   


### PR DESCRIPTION
Adds metadata support to `addDocuments`.

- Add `ChromaMetadata` types and `addDocuments` overload for metadata arrays
- Add `decodedMetadatas()` helper for typed metadata reads

Note: addDocuments currently returns 1 on success as-per binding. See https://github.com/narner/chroma/blob/86b3534acb8fa4480353b540c853b28f8b7e8de9/rust/swift_bindings/src/lib.rs#L308

Fixes #2 